### PR TITLE
Fix deploy to heroku

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -45,10 +45,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7.2'
-      # - name: Install dependencies
-      #   run: bundle install
-      # - name: Create DB
-      #   run: bin/rails db:create db:migrate
       - name: Update solidus_bolt gem
         run: bundle update solidus_bolt --conservative
       - name: Run generator
@@ -56,7 +52,3 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Update solidus_bolt
-      - name: Deploy to Heroku
-        run: git push heroku master
-      - name: Run migrations on Heroku and clear seeds
-        run: heroku run rails db:migrate db:seed

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+release: run rails db:migrate db:seed


### PR DESCRIPTION
Previous implementation errored out due to
```
fatal: 'heroku' does not appear to be a git repository
fatal: Could not read from remote repository.
```
Removing the code related to deploying to Heroku and instead will handle deployment on Heroku's side by connecting to GitHub. The Procfile serves to run the migration and seeds with each deployment.