### PR TITLE
Remove Useless fields from Login Form

### DIFF
--- a/app/overrides/spree/shared/_login/remove_useless_fields.deface
+++ b/app/overrides/spree/shared/_login/remove_useless_fields.deface
@@ -1,0 +1,2 @@
+remove "erb[loud]:contains('f.check_box :remember_me'), erb[loud]:contains('f.label :remember_me'), erb[loud]:contains('f.submit')"
+

--- a/app/overrides/spree/shared/_login/replace_password_credentials_div.html.erb.deface
+++ b/app/overrides/spree/shared/_login/replace_password_credentials_div.html.erb.deface
@@ -1,0 +1,6 @@
+<!-- replace_contents '#password-credentials' -->
+
+<p>
+  <%= f.label :email, t('spree.email') %><br />
+  <%= f.email_field :email, class: 'title', tabindex: 1, autofocus: true %>
+</p>

--- a/app/overrides/spree/user_sessions/new/remove_forgot_password_field.deface
+++ b/app/overrides/spree/user_sessions/new/remove_forgot_password_field.deface
@@ -1,0 +1,1 @@
+remove "erb[loud]:contains('spree.recover_password_path')"


### PR DESCRIPTION
This PR removes useless fields from the Login Form.

Fields removed are
- Password
- Remember me
- Forgot Password
- Login