### PR TITLE
automatically add payment method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/nebulab/solidus_bolt.git
-  revision: 28bf92279cfa4a3d8c68c18f416a5e341b68cd25
+  revision: f59aaa2dc91ca933c888013a0eb768c422fbe742
   specs:
     solidus_bolt (0.0.1)
       coffee-rails
@@ -176,7 +176,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    jwt (2.4.0)
+    jwt (2.4.1)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -505,4 +505,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.2.25
+   2.3.11

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-release: bundle exec rails db:migrate db:seed db:seed:solidus_bolt

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,3 +10,6 @@ DatabaseCleaner.clean
 Spree::Core::Engine.load_seed if defined?(Spree::Core)
 Spree::Auth::Engine.load_seed if defined?(Spree::Auth)
 SpreeSample::Engine.load_samples if defined?(SpreeSample)
+SolidusBolt::Engine.load_seed if defined?(SolidusBolt) && ENV['environment']
+
+Spree::PaymentMethod.where.not(type: 'SolidusBolt::PaymentMethod').update_all(available_to_users: false)


### PR DESCRIPTION
- Automatically add Bolt PaymentMethod: import seeds from solidus_bolt and allow only Bolt's payment method to be available to users
- Remove Procfile: avoid deployment error due to faulty file

Fixes https://github.com/nebulab/bolt_demo/issues/17