### PR TITLE
Restore Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+release: bundle exec rails db:migrate db:seed


### PR DESCRIPTION
We remove the Procfile in an older commit due to deploy errors. After
investigating we are bringing it back, removing the running of
solidus_bolt seeds (as those have been included in the seed file) and
adding `AUTO_ACCEPT=true` to the env secrets, which will automatically
create an admin user.
